### PR TITLE
workflows: Add initial CI using tox

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  push:
+  pull_request:
+
+jobs:
+  tox:
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:latest
+    permissions: {}
+    timeout-minutes: 10
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Install test dependencies
+        run: dnf install -y tox python3-pytest-cov python3-pytest-timeout
+
+      - name: Run test with site packages
+        run: tox
+
+      - name: Run test for Python 3.12 venv
+        run: tox -e py312
+
+      - name: Run test for Python 3.11 venv
+        run: tox -e py311


### PR DESCRIPTION
Run tests with a tox venv for recent Python versions, and also against
the Fedora packages ("site"). Our code is not yet compatible with Python
< 3.11, but it's easy enough to add testing of older versions in PRs
which fix the code.

---

This [works for Fedora rawhide and 38](https://github.com/martinpitt/beipack/actions/runs/5178404345) , but it already [fails on C9S](https://github.com/martinpitt/beipack/actions/runs/5178339045/jobs/9329659324):
```
test/test_beipack.py:52: in <module>
    pytestconfig: pytest.Config) -> None:
E   AttributeError: module 'pytest' has no attribute 'Config'
```
once I "fix" that by taking out the type, it fails on

```
ModuleNotFoundError: No module named 'importlib.resources.abc'; 'importlib.resources' is not a package
```

So it's not even compatible with Python 3.9. I think we need to fix that before actually using it for a wider audience.