### PR TITLE
pyproject: tweak tox config a bit more

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,6 @@ commands=
   python3 -m pytest {posargs}
 
 [testenv:site]
-install_command = python3 -m pip install --no-index --no-build-isolation
+install_command = python3 -m pip install --no-index --no-build-isolation {opts} {packages}
 system_site_packages = True
 """


### PR DESCRIPTION
The docs say that `{packages}` is required to appear here and `{opts}` should too, (although it works without either).  Let's follow the docs, though.